### PR TITLE
Update C7 driver Makefile for Ubuntu 20.04

### DIFF
--- a/driver_c7/Makefile.in
+++ b/driver_c7/Makefile.in
@@ -41,7 +41,7 @@ DRIVER_FILE = $(DRIVER_NAME).ko
 ifeq ($(KERNELRELEASE),) # we are in the source folder
 
 modules: autoversion.h ../defaults/config.h
-	$(MAKE) -C $(KERNELDIR) SUBDIRS=$(src) modules
+	$(MAKE) -C $(KERNELDIR) M=$(src) modules
 
 else # we are in the kernel source tree
 

--- a/driver_c7/reload
+++ b/driver_c7/reload
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-DRIVER=mce_dsp
+DRIVER=mce_dsp_c7
 
 grep '^mce_dsp\ ' /proc/modules && \
     sudo rmmod ${DRIVER}


### PR DESCRIPTION
I was able to get MAS (and MCE Script), with the C7 driver, working on Ubuntu 20.04 (Linux 5.4.0-66-generic) with only a minor change to the Makefile. The `SUBDIRS` parameter, which has now been removed, was replaced with the `M` parameter in Linux v2.6 or earlier (the change predates the kernel's switch to Git), so it should be safe for older kernel versions. The patch also includes a fix for the `reload` script, which I suspect never worked with the C7 driver.

Since Ubuntu 20.04 dropped Python 2 from the main repositories, it also needs to be installed differently. I needed to install one other Python 2 package after the upgrade from Ubuntu 18.04, but a clean install may need additional packages installed:
```
sudo add-apt-repository universe
sudo apt update
sudo apt install python2 build-essential libx11-dev libxft-dev libxt-dev libxaw7-dev libpng-dev ghostscript libplot-dev
wget https://bootstrap.pypa.io/2.7/get-pip.py
sudo python2 get-pip.py
rm get-pip.py
sudo pip2 install biggles
```