### PR TITLE
Fix issue with Dirfile samples being dropped when writing to NFS mounts

### DIFF
--- a/interfaces/mce_library/dirfile.c
+++ b/interfaces/mce_library/dirfile.c
@@ -179,6 +179,7 @@ static int dirfile_write(mce_acq_t *acq, dirfile_t *f)
         fwrite(c->data, c->count, sizeof(uint32_t), c->fout);
 		c->count = 0;
 		writes++;
+		fflush(c->fout); // Avoid issue with dropped samples when writing to NFS mount
 	}
 
 	return 0;


### PR DESCRIPTION
Without this change, CLASS was experiencing dropped Dirfile samples when writing to NFS mounts; there were no issues when writing to a local disk. I was never able to track down the exact cause of the issue, and I don't know if the fix is optimal. However, it successfully fixed the problem CLASS was having. CLASS has been running this patch in production for almost three years without issues.