### PR TITLE
Get driver working under Ubuntu 22.04

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,5 @@ configure
 defaults
 repo_version.txt
 autom4te.cache/
+
+driver_c7/mce_dsp_c7.mod

--- a/.gitignore
+++ b/.gitignore
@@ -62,4 +62,5 @@ defaults
 repo_version.txt
 autom4te.cache/
 
+driver_c6/mce_dsp_c6.mod
 driver_c7/mce_dsp_c7.mod

--- a/config2/components/header
+++ b/config2/components/header
@@ -57,6 +57,8 @@ if (isset($hw_num_rows))
 if (($num_rows_rc > 55) ||
     (isset($force_bank_scheme1) && $force_bank_scheme1)) {
    $use_bank_scheme1 = 1;
+} else {
+   $use_bank_scheme1 = 0;
 }
 
 /* "sys" cards -- order and eligibility */

--- a/driver_c6/Makefile.2.6
+++ b/driver_c6/Makefile.2.6
@@ -12,7 +12,7 @@ DRIVER_FILE = $(DRIVER_NAME).ko
 ifeq ($(KERNELRELEASE),) # we are in the source folder
 
 modules: autoversion.h ../defaults/config.h
-	$(MAKE) -C $(KERNELDIR) SUBDIRS=$(src) modules
+	$(MAKE) -C $(KERNELDIR) M=$(src) modules
 
 else # we are in the kernel source tree
 

--- a/driver_c6/data.c
+++ b/driver_c6/data.c
@@ -466,7 +466,7 @@ int data_alloc(int mem_size, int data_size, int card)
 
     // Save physical address for hardware
     dframes->base_busaddr = phys;
-    dframes->base = &virt;
+    dframes->base = virt;
 
 #endif /* MEMMAP */
 

--- a/driver_c6/mce_options.h
+++ b/driver_c6/mce_options.h
@@ -61,7 +61,7 @@
 
 #ifndef BIGPHYS
 
-#  define FRAME_BUFFER_SIZE (32*1024*1024)
+#  define FRAME_BUFFER_SIZE (4*1024*1024)
 
 #else
 

--- a/driver_c6/proc.c
+++ b/driver_c6/proc.c
@@ -65,6 +65,14 @@ static int mcedsp_proc_open(struct inode *inode, struct file *file)
     return single_open(file, &proc_show, NULL);
 }
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,6,0)
+const struct proc_ops mcedsp_proc_ops = {
+    .proc_open = mcedsp_proc_open,
+    .proc_read = seq_read,
+    .proc_lseek = seq_lseek,
+    .proc_release = single_release
+};
+#else
 const struct file_operations mcedsp_proc_ops = {
     .owner = THIS_MODULE,
     .open = mcedsp_proc_open,
@@ -72,3 +80,4 @@ const struct file_operations mcedsp_proc_ops = {
     .llseek = seq_lseek,
     .release = single_release
 };
+#endif

--- a/driver_c6/proc.h
+++ b/driver_c6/proc.h
@@ -7,12 +7,17 @@
 #include <linux/module.h>
 #include <linux/proc_fs.h>
 #include <linux/seq_file.h>
+#include <linux/version.h>
 
 int mce_proc(struct seq_file *sfile, void *data);
 int dsp_proc(struct seq_file *sfile, void *data);
 int data_proc(struct seq_file *sfile, void *data);
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,6,0)
+extern const struct proc_ops mcedsp_proc_ops;
+#else
 extern const struct file_operations mcedsp_proc_ops;
+#endif
 
 
 #endif

--- a/driver_c6/reload
+++ b/driver_c6/reload
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-DRIVER=mce_dsp
+DRIVER=mce_dsp_c6
 
 grep '^mce_dsp\ ' /proc/modules && \
     sudo rmmod ${DRIVER}

--- a/interfaces/mce_library/acq.c
+++ b/interfaces/mce_library/acq.c
@@ -449,6 +449,8 @@ int copy_frames_mmap(mce_acq_t *acq)
             if (frame_property(data, &frame_header_v6, status_v6)
                     & FRAME_STATUS_V6_LAST)
                 done = EXIT_LAST;
+        } else {
+            mcelib_warning(acq->context, "checksum verification failed\n");
         }
 
         // Inform driver of consumption

--- a/interfaces/mce_library/cmd.c
+++ b/interfaces/mce_library/cmd.c
@@ -291,7 +291,7 @@ int mcecmd_send_command_simple(mce_context_t* context, int card_id, int para_id,
         .card_id  = (u16)card_id,
         .para_id  = (u16)para_id,
         .count    = 1
-    }
+    };
 
     cmd.data[0] = 1;
     cmd.checksum = mcecmd_cmd_checksum(&cmd);

--- a/interfaces/mce_library/dirfile.c
+++ b/interfaces/mce_library/dirfile.c
@@ -529,7 +529,7 @@ static int dirfile_destructor(mcedata_storage_t *storage)
     // Free the private data for the storage module, clear the structure
     dirfile_t *f = (dirfile_t*)storage->action_data;
     dirfile_free(f);
-    FREE_NOT_NULL(f)
+    FREE_NOT_NULL(f);
 
         memset(storage, 0, sizeof(*storage));
     return 0;
@@ -654,7 +654,7 @@ static int dirfileseq_destructor(mcedata_storage_t *storage)
     // Free the private data for the storage module, clear the structure
     dirfileseq_t *f = (dirfileseq_t*)storage->action_data;
     dirfile_free(&f->active_dirfile);
-    FREE_NOT_NULL(f)
+    FREE_NOT_NULL(f);
 
         memset(storage, 0, sizeof(*storage));
     return 0;


### PR DESCRIPTION
A couple minor changes were required to get the C7 driver working under Ubuntu 22.04 and Linux 5.15.0.

Other than these changes, there are a couple things regarding Python 2 that need to be done differently for Ubuntu 22.04. A symlink needs to be set up to have `python` call `python2` (`sudo ln -s /usr/bin/python2 /usr/bin/python`), and NumPy and Biggles need to be installed via `pip2` (distro packages no longer exist for them). At first, I also patched MAS to work with a `python2` executable name, but MCE Script also required changes in that case, so I went with the simpler option of setting up the symlink.

I also fixed the build issues that have been around since last year, which were caused by missing semicolons.